### PR TITLE
Add ListModels method to AI implementations

### DIFF
--- a/ai.go
+++ b/ai.go
@@ -13,6 +13,8 @@ type AI interface {
 	LLMs() LLMs
 	Model() string
 
+	ListModels(context.Context) ([]string, error)
+
 	Limiter
 
 	SetModel(string)

--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -141,6 +141,19 @@ func (ai *Anthropic) SetJSONResponse(_ bool, _ *ai.JSONSchema) {
 	fmt.Println("Anthropic currently doesn't support SetJSONResponse")
 }
 
+func (ai *Anthropic) ListModels(ctx context.Context) ([]string, error) {
+	iter := ai.Client.Models.ListAutoPaging(ctx, anthropic.ModelListParams{Limit: param.NewOpt[int64](1000)})
+	var res []string
+	for iter.Next() {
+		model := iter.Current()
+		res = append(res, model.ID)
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 var _ ai.ChatResponse = new(ChatResponse[*anthropic.Message])
 
 type ChatCompletionResponse interface {

--- a/chatgpt/chatgpt.go
+++ b/chatgpt/chatgpt.go
@@ -157,6 +157,19 @@ func (ai *ChatGPT) SetJSONResponse(set bool, schema *ai.JSONSchema) {
 	ai.json = responseFormat
 }
 
+func (ai *ChatGPT) ListModels(ctx context.Context) ([]string, error) {
+	iter := ai.Client.Models.ListAutoPaging(ctx)
+	var res []string
+	for iter.Next() {
+		model := iter.Current()
+		res = append(res, model.ID)
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 var _ ai.ChatResponse = new(ChatResponse[*openai.ChatCompletion])
 
 type ChatCompletionResponse interface {

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -182,6 +182,17 @@ func (ai *Gemini) SetJSONResponse(set bool, schema *ai.JSONSchema) {
 	}
 }
 
+func (ai *Gemini) ListModels(ctx context.Context) ([]string, error) {
+	var models []string
+	for i, err := range ai.Models.All(ctx) {
+		if err != nil {
+			return nil, err
+		}
+		models = append(models, i.Name)
+	}
+	return models, nil
+}
+
 func toParts(src []ai.Part) (dst []*genai.Part) {
 	for _, i := range src {
 		switch v := i.(type) {


### PR DESCRIPTION
Introduces the ListModels method to the AI interface and implements it for Anthropic, ChatGPT, and Gemini providers, allowing retrieval of available model IDs for each provider.